### PR TITLE
fix: 5 bugs found during integration testing

### DIFF
--- a/src/commands/db/auth.ts
+++ b/src/commands/db/auth.ts
@@ -158,8 +158,8 @@ const roleSub = async (
   }
   const auth = await reg.getAuth();
   try {
-    if (op === "assign") auth.assignRole(targetUser, role);
-    else if (op === "remove") auth.removeRole(targetUser, role);
+    if (op === "assign") await auth.assignRole(targetUser, role);
+    else if (op === "remove") await auth.removeRole(targetUser, role);
     else throw new CommandError(EXIT.USAGE, `unknown role op: ${op}`);
   } catch (err) {
     if (err instanceof CommandError) throw err;

--- a/src/commands/db/crud.ts
+++ b/src/commands/db/crud.ts
@@ -250,9 +250,11 @@ export const aggregateHandler = async (
       case "$project":
         pipe = pipe.project(arg as Record<string, unknown>);
         break;
-      case "$unwind":
-        pipe = pipe.unwind(arg as string);
+      case "$unwind": {
+        const unwindField = typeof arg === "string" && arg.startsWith("$") ? arg.slice(1) : arg;
+        pipe = pipe.unwind(unwindField as string);
         break;
+      }
       default:
         throw new CommandError(EXIT.USAGE, `unknown aggregation operator: ${op}`);
     }

--- a/src/commands/db/meta.ts
+++ b/src/commands/db/meta.ts
@@ -26,7 +26,7 @@ export const indexHandler = async (
       const sorted = flagBool(parsed.flags, "sorted");
       const unique = flagBool(parsed.flags, "unique");
       try {
-        c.createIndex(field, { sorted, unique });
+        c.createIndex(field, { type: sorted ? "sorted" : "hash", unique });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         if (msg.includes("Unique constraint")) {

--- a/src/commands/vec/ops.ts
+++ b/src/commands/vec/ops.ts
@@ -220,7 +220,7 @@ export const storeBatchOp = async (
       throw new CommandError(EXIT.VALIDATION, `validation: id collision: ${check.id}`);
     }
     const rec = parsedRec as Record<string, unknown>;
-    const recMeta = rec["meta"];
+    const recMeta = rec["metadata"] ?? rec["meta"];
     const meta = recMeta && typeof recMeta === "object" && !Array.isArray(recMeta)
       ? (recMeta as Record<string, unknown>)
       : {};
@@ -473,7 +473,11 @@ export const importOp = async (
     throw new CommandError(EXIT.VALIDATION, "validation: invalid JSON for import");
   }
   if (!Array.isArray(parsedInput)) {
-    throw new CommandError(EXIT.VALIDATION, "validation: import expects an array of records");
+    if (parsedInput && typeof parsedInput === "object" && Array.isArray((parsedInput as Record<string, unknown>)["records"])) {
+      parsedInput = (parsedInput as Record<string, unknown>)["records"];
+    } else {
+      throw new CommandError(EXIT.VALIDATION, "validation: import expects an array of records");
+    }
   }
   // Validate every record before handing off to upstream — surface clear
   // errors with the offending index instead of letting upstream throw an


### PR DESCRIPTION
## Summary

- **#1 auth role assign**: `await` added to `assignRole()`/`removeRole()` — fixes empty stdout
- **#2 sorted index**: Pass `{ type: 'sorted' }` to `createIndex()` instead of `{ sorted: true }` — fixes `--sorted` flag being ignored
- **#3 vec import/export**: `importOp` now accepts `{ exported, records }` wrapper from `exportOp`, not just bare arrays
- **#4 store-batch metadata**: Read `rec["metadata"]` (with `rec["meta"]` fallback) instead of only `rec["meta"]` — fixes metadata loss in batch inserts
- **#5 $unwind**: Strip leading `$` from field name before passing to `js-doc-store` `unwind()` — fixes arrays not being flattened

## Test plan

- [x] 264/264 existing tests pass
- [x] 12/12 new fix verification tests pass (all 5 fixes confirmed)
- [x] Build succeeds with `tsup`

Closes #1, #2, #3, #4, #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)